### PR TITLE
Adjust blog spacing in app/dev_blog/page.tsx

### DIFF
--- a/app/dev_blog/page.tsx
+++ b/app/dev_blog/page.tsx
@@ -21,7 +21,7 @@ export default function DevBlog() {
 
       {/* Blog Posts List */}
       <div className="max-w-4xl mx-auto py-12 px-4">
-        <div className="space-y-6">
+        <div className="flex flex-col gap-10">
           {posts.length === 0 ? (
             <div className="text-center text-stone-400 py-12">
               No blog posts yet.


### PR DESCRIPTION
## Description
Switched from margin based spacing to flexbox due to issues with components not utilizing spacing correctly.

## Current:
<img width="1920" height="1040" alt="before" src="https://github.com/user-attachments/assets/e896cdc5-f7b6-4ac1-917f-2607109051e4" />


## Pull Request:
<img width="1920" height="1040" alt="after" src="https://github.com/user-attachments/assets/9fc5b3db-e84e-423e-b41f-1bebaae5645e" />
